### PR TITLE
Remove ambiguity from help

### DIFF
--- a/data/help.txt
+++ b/data/help.txt
@@ -1,9 +1,9 @@
 Use !notify to send messages to other people who are currently unavailable.
-                !notify @PERSON (@PERSON2, @PERSON3...) MESSAGE
+                !notify @PERSON (@PERSON2 @PERSON3...) MESSAGE
                 !notify *GROUP MESSAGE
 Use !group and !ungroup to add yourself (or anyone else) to a group that can send and receive messages just like a person.
-                !group *GROUP @PERSON (@PERSON2, @PERSON3...)
-                !ungroup *GROUP @PERSON (@PERSON2, @PERSON3...)
+                !group *GROUP @PERSON (@PERSON2 @PERSON3...)
+                !ungroup *GROUP @PERSON (@PERSON2 @PERSON3...)
 Use !grouplist to see all the groups and to see their occupants.
                 !grouplist
                 !grouplist (-ping) *GROUP


### PR DESCRIPTION
The help message regularly led users to (most visibly; other occasions are not excluded) separate items on the !group command line with commata (instead of whitespace). Removing the commata from it should improve that.
