### PR TITLE
Avoid getting kicked for flooding

### DIFF
--- a/source/notifybot.py
+++ b/source/notifybot.py
@@ -69,7 +69,9 @@ class NotifyBot(euphoria.ping_room.PingRoom, euphoria.standard_room.StandardRoom
         user = ut.filter_nick(info["sender"]["name"])
         if self.messages.has_notifications(user):
             ms = self.messages.get_notifications(user)
-            for m in ms:
+            for n, m in enumerate(ms):
+                # HACK: Avoid getting kicked for flooding
+                if n >= 5: time.sleep(1)
                 self.send_chat(m, info["id"])
                 
         #Now, begin proccessing the message


### PR DESCRIPTION
If too many notifies (more than ca. 15) are delivered, the bot gets kicked for flooding, and the remaining messages are never delivered. This adds a very crude workaround for that.

Severity level: HIGH (data loss possible)